### PR TITLE
Regenerate certificates if data has changed

### DIFF
--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -279,7 +279,6 @@ def create_server_certificate(cn, san_list, name='server'):
             remove_file_if_exists(key_file)
             remove_file_if_exists(req_file)
         if changed or not cert_exists:
-            # Get a string compatible with easyrsa for the subject-alt-names.
             # Create a server certificate for the server based on the CN.
             server = './easyrsa --batch --req-cn={0} --subject-alt-name={1} ' \
                      'build-server-full {2} nopass 2>&1'.format(cn, sans, name)

--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -11,6 +11,7 @@ from charms.reactive import remove_state
 from charms.reactive import set_state
 from charms.reactive import when
 from charms.reactive import when_not
+from charms.reactive.helpers import data_changed
 
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
@@ -258,7 +259,7 @@ def create_server_certificate(cn, san_list, name='server'):
         # Get a string compatible with easyrsa for the subject-alt-names.
         sans = get_sans(san_list)
         this_cert = {'sans': sans, 'cn': cn, 'name': name}
-        changed = helpers.data_changed('server_cert', this_cert)
+        changed = data_changed('server_cert', this_cert)
         # Do not regenerate the server certificate if it already exists
         # and the data hasn't changed.
         if changed:

--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -260,9 +260,10 @@ def create_server_certificate(cn, san_list, name='server'):
         sans = get_sans(san_list)
         this_cert = {'sans': sans, 'cn': cn, 'name': name}
         changed = data_changed('server_cert', this_cert)
+        cert_exists = os.path.isfile(cert_file) and os.path.isfile(key_file)
         # Do not regenerate the server certificate if it already exists
         # and the data hasn't changed.
-        if changed:
+        if changed and cert_exists:
             # We need to revoke the existing cert and regenerate it
             revoke = './easyrsa --batch revoke {0}'.format(name)
             check_call(split(revoke))
@@ -270,7 +271,6 @@ def create_server_certificate(cn, san_list, name='server'):
             remove_file_if_exists(cert_file)
             remove_file_if_exists(key_file)
             remove_file_if_exists(req_file)
-        cert_exists = os.path.isfile(cert_file) and os.path.isfile(key_file)
         if changed or not cert_exists:
             # Get a string compatible with easyrsa for the subject-alt-names.
             # Create a server certificate for the server based on the CN.

--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -244,6 +244,13 @@ def upgrade():
     remove_state('easyrsa.configured')
 
 
+def remove_file_if_exists(filename):
+    try:
+        os.remove(filename)
+    except FileNotFoundError:
+        pass
+
+
 def create_server_certificate(cn, san_list, name='server'):
     '''Return a newly created server certificate and server key from a
     common name, list of Subject Alternate Names, and the certificate name.'''

--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -266,7 +266,7 @@ def create_server_certificate(cn, san_list, name='server'):
         # Get a string compatible with easyrsa for the subject-alt-names.
         sans = get_sans(san_list)
         this_cert = {'sans': sans, 'cn': cn, 'name': name}
-        changed = data_changed('server_cert', this_cert)
+        changed = data_changed('server_cert.' + name, this_cert)
         cert_exists = os.path.isfile(cert_file) and os.path.isfile(key_file)
         # Do not regenerate the server certificate if it already exists
         # and the data hasn't changed.


### PR DESCRIPTION
This makes easyrsa revoke, delete the old certificate, and then generate a new certificate if the data that makes up the certificate has changed.