### PR TITLE
Fix create_client_cert never running

### DIFF
--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -252,7 +252,7 @@ def create_server_cert():
         request.set_cert(server_cert, server_key)
 
 
-@when('client.client.certs.requested', 'easyrsa.configured')
+@when('client.client.cert.requested', 'easyrsa.configured')
 def create_client_cert():
     '''Create client certificates with the request information from the
     relation object.'''


### PR DESCRIPTION
Still testing.

I had a failing deployment where `create_client_cert` never ran. I think because the actual flag has "cert", not "certs", as set [here](https://github.com/juju-solutions/interface-tls-certificates/blob/e02ffd6593576689d75aad6f59533ddf0563d1a4/provides.py#L44)