### PR TITLE
Harden build-client-full against whitespace in name.

### DIFF
--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -399,8 +399,7 @@ def create_client_certificate(name='client'):
         # Do not regenerate the client certificate if it already exists.
         if not os.path.isfile(cert_file) and not os.path.isfile(key_file):
             # Create a client certificate and key.
-            client = './easyrsa build-client-full {0} nopass'.format(name)
-            check_call(split(client))
+            check_call(['./easyrsa', 'build-client-full', name, 'nopass'])
         # Read the client certificate from the file system.
         with open(cert_file, 'r') as stream:
             client_cert = stream.read()


### PR DESCRIPTION
Fixes [LP:#1848095](https://bugs.launchpad.net/charm-easyrsa/+bug/1848095). It might be a good idea to harden other `check_call` calls against whitespaces in names but this fixes our immediate issue.