### PR TITLE
add section in upgrade that will check if ca_serial needs to/can be set

### DIFF
--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -336,10 +336,10 @@ def upgrade():
                     leader_get('certificate_authority_key') and not \
                     leader_get('certificate_authority_serial'):
                 with open(serial_file, 'r') as stream:
-                    certificate_authority_serial = stream.read()
+                    ca_serial = stream.read()
                 # set the previously unset certificate authority serial
                 leader_set({
-                    'certificate_authority_serial': certificate_authority_serial})
+                    'certificate_authority_serial': ca_serial})
 
         charm_pki_directory = os.path.join(charm_directory, 'pki')
         # When the charm pki directory exists, it is stale, remove it.

--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -164,7 +164,8 @@ def create_certificate_authority():
 
     with chdir(easyrsa_directory):
         if leader_get('certificate_authority') and \
-                leader_get('certificate_authority_key'):
+                leader_get('certificate_authority_key') and \
+                leader_get('certificate_authority_serial'):
             hookenv.log('Recovering CA from controller')
             certificate_authority = \
                 leader_get('certificate_authority')
@@ -324,6 +325,22 @@ def upgrade():
     '''An upgrade has been triggered.'''
     pki_directory = os.path.join(easyrsa_directory, 'pki')
     if os.path.isdir(pki_directory):
+        # specific handling if the upgrade is from a previous version
+        # where certificate_authority_serial is not set at install
+        serial_file = 'serial'
+        with chdir(pki_directory):
+            # if the ca and ca_key are set and serial is not
+            # set this to serial in the pki directory
+            if os.path.isfile(serial_file) and \
+                    leader_get('certificate_authority') and \
+                    leader_get('certificate_authority_key') and not \
+                    leader_get('certificate_authority_serial'):
+                with open(serial_file, 'r') as stream:
+                    certificate_authority_serial = stream.read()
+                # set the previously unset certificate authority serial
+                leader_set({
+                    'certificate_authority_serial': certificate_authority_serial})
+
         charm_pki_directory = os.path.join(charm_directory, 'pki')
         # When the charm pki directory exists, it is stale, remove it.
         if os.path.isdir(charm_pki_directory):

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -89,7 +89,7 @@ def validate_certificate(cert):
 def validate_key(key):
     '''Return true if the key is valid, false otherwise.'''
     # The key should not be empty string and have begin and end statements.
-    return key and 'BEGIN PRIVATE KEY'in key and 'END PRIVATE KEY' in key
+    return key and 'BEGIN PRIVATE KEY' in key and 'END PRIVATE KEY' in key
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bug report: [1]

This resolves the issue on an LXD cluster, but it would be good to test on AWS.

My thought process:

- Since the issue shows up when upgrading from a previous version [2] where `certificate_authority_serial` is not set on install, my thought is that we should just check if `certificate_authority` and `certificate_authority_key` are set and `certificate_authority_serial` is not set when an upgrade was triggered. If these three conditions are met (and the file exists), we just set `certificate_authority_serial` during the upgrade process.
- If we still cannot set `certificate_authority_serial` in the upgrade, then I think we need an additional condition in `create_certificate_authority()` (line 168).

[1] https://bugs.launchpad.net/charm-easyrsa/+bug/1888580
[2] https://github.com/charmed-kubernetes/layer-easyrsa/pull/21/files