### PR TITLE
Fix excluding of unit tests from built charm

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -10,5 +10,8 @@ options:
       - openssl
 repo: http://github.com/juju-solutions/layer-easyrsa.git
 exclude:
-  - tests/10-deploy.py
-  - tests/tests.yaml
+  - .tox
+  - __pycache__
+  - tests
+  - conftest.py
+  - tox.ini


### PR DESCRIPTION
The layer.yaml excludes entries for excluding layer unit tests from the built charm was not updated when switched from Amulet style tests to the current test pattern.

Fixes [lp:1903073](https://bugs.launchpad.net/charm-easyrsa/+bug/1903073)