### PR TITLE
Using network_get to get public address

### DIFF
--- a/reactive/easyrsa.py
+++ b/reactive/easyrsa.py
@@ -198,14 +198,14 @@ def create_certificate_authority():
             # The Common Name (CN) for a certificate
             # must be an IP or hostname. In case the IP of the unit is
             # not ready, it will set the unit in blocked state without
-            # changing the charm flags to run again when the IP probably
-            # will be ready
+            # changing the charm flags to run again when the IP will
+            # probably be ready
             try:
                 cn = hookenv.network_get('client')['ingress-addresses'][0]
-            except CalledProcessError as e:
+            except (CalledProcessError, KeyError, IndexError) as e:
                 msg = 'Public address not available yet'
                 hookenv.log(msg, hookenv.WARNING)
-                hookenv.log(e, hookenv.ERROR)
+                hookenv.log(e, hookenv.WARNING)
                 status.blocked(msg)
                 return
             # Create a self signed CA with the CN, stored pki/ca.crt


### PR DESCRIPTION
This PR attempts to solve the [bug/1924780](https://bugs.launchpad.net/charm-easyrsa/+bug/1924780) where the hook fails when trying to get the public address.

Talking with Juju team member, the method `unit_get` is deprecated and they recommend implementing the method `network-get` where any public address should appear under `ingress-addresses` .  Apparently, `unit-get`  looks at an address stored against the machine without really taking into account the proper network model.

If the endpoint is bound to a space, the ingress address(es) will be in the space subnet(s). Juju right now doesn't model it any better than that and using the flag `--ingress-address` gets the first ingress address. That is why I'm always considering to get the first address as the public address to the unit.

After this change I couldn't reproduce the bug. I've deployed the Kubernetes bundle more than 10 times and none resulted in the issue. But as an extra security, it was added a try and except to catch the error, log it, block the unit and return nothing to keep the machine state so in the next run, it's very likely that the unit will have enough time to have the public address.

Note: I suggest to merge this PR after the [PR#33](https://github.com/charmed-kubernetes/layer-easyrsa/pull/33/files) and then I can update the unit tests.