### PR TITLE
Adding support from focal to noble

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -10,13 +10,17 @@ on:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 
   lint-unit:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.10', '3.12']"
 
   validate-wheelhouse:
-    uses: charmed-kubernetes/workflows/.github/workflows/validate-wheelhouse.yaml@main 
+    uses: charmed-kubernetes/workflows/.github/workflows/validate-wheelhouse.yaml@main
+    with:
+      python: "['3.8', '3.10', '3.12']" 

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 .cache
 .coverage
 .unit-state.db
+*.tgz
+*.charm
 *__pycache__
 *.pyc

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,5 +28,6 @@ resources:
       not work. You can find the releases of EasyRSA at 
       https://github.com/OpenVPN/easy-rsa/releases
 series:
+  - noble
   - jammy
   - focal

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -499,7 +499,7 @@ class RestoreActionTests(_ActionTestCase):
         ]
 
         actions._update_leadership_data("foo", "bar", "baz")
-        actions.leader_set.has_calls(leader_set_calls, any_order=True)
+        actions.leader_set.assert_has_calls(leader_set_calls, any_order=True)
 
     def test_restore_action_all_certs_found(self):
         """Test 'restore' action without generating new certs.

--- a/tests/test_easyrsa.py
+++ b/tests/test_easyrsa.py
@@ -1,4 +1,5 @@
 """Unit tests for easyrsa reactive layer."""
+
 from os import path
 from shlex import split
 from unittest import TestCase

--- a/tests/validate-wheelhouse.sh
+++ b/tests/validate-wheelhouse.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -eux
 
 build_dir="$(mktemp -d)"
 charm="$(egrep '^name\S*:' ./metadata.yaml | awk '{ print $2 }')"
 function cleanup { rm -rf "$build_dir"; }
 trap cleanup EXIT
 
-charm build . --build-dir "$build_dir" --debug
+charm-build . --build-dir "$build_dir" --debug
 pip install -f "$build_dir/$charm/wheelhouse" --no-index --no-cache-dir "$build_dir"/"$charm"/wheelhouse/* 

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands = black {toxinidir}/reactive {toxinidir}/tests {toxinidir}/actions
 [testenv:validate-wheelhouse]
 deps = 
    git+https://github.com/juju/charm-tools.git
+   path<17
 allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
 commands = {toxinidir}/tests/validate-wheelhouse.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 commands =
     pytest -v -s \
     --cov=actions \
-    --cov=reactive\
+    --cov=reactive \
     --cov-fail-under 100 \
     --cov-report=term-missing \
     tests/ \
@@ -42,12 +42,8 @@ deps =
 commands = black {toxinidir}/reactive {toxinidir}/tests {toxinidir}/actions
 
 [testenv:validate-wheelhouse]
-deps =
-# Temporarily pin setuptools to avoid the breaking change from 58 until
-# all dependencies we use have a chance to update.
-# See: https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0
-# and: https://github.com/pypa/setuptools/issues/2784#issuecomment-917663223
-    setuptools<58
+deps = 
+   git+https://github.com/juju/charm-tools.git
 allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
 commands = {toxinidir}/tests/validate-wheelhouse.sh
 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,2 @@
+charms.reactive @ git+https://github.com/canonical/charms.reactive.git
+setuptools==70.3.0

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,2 @@
-charms.reactive @ git+https://github.com/canonical/charms.reactive.git
+charms.reactive==1.5.3
 setuptools==70.3.0


### PR DESCRIPTION
## Overview 
To support running on `noble` and `jammy` while still building/running on `focal` update python charm libaries

## Details
* Update metadata to support noble
* Block out any resources or charm files built in the local path
* Adding `wheelhouse.txt` to update `charms.reactive` and `setuptools`
* Fix issues with linting and testing with upgraded tox
* Fix issues with updated charm-tools to support noble
* Map to corrected inclusive naming checks