### PR TITLE
Create a pki/ copy of the `openssl-*.conf` file

### DIFF
--- a/src/reactive/easyrsa.py
+++ b/src/reactive/easyrsa.py
@@ -112,28 +112,27 @@ def configure_copy_extensions():
     """Update the EasyRSA configuration with the capacity to copy the extensions
     through to the resulting certificates."""
 
-    openssl_confs = Path(easyrsa_directory).glob("openssl-*.cnf")
+    (openssl_file,) = Path(easyrsa_directory).glob("openssl-*.cnf")
     # Update EasyRSA configuration with the capacity to copy CSR Requested
     # Extensions through to the resulting certificate. This can be tricky,
     # and the implications are not fully clear on this.
 
-    for openssl_file in openssl_confs:
-        conf = openssl_file.read_text().splitlines(True)
-        # When the copy_extensions key is not in the configuration.
-        if "copy_extensions = copy\n" not in conf:
-            for idx, line in enumerate(conf):
-                if "[ CA_default ]" in line:
-                    # Insert a new line with the copy_extensions key set to copy.
-                    conf.insert(idx + 1, "copy_extensions = copy\n")
-            openssl_file.write_text("\n".join(conf))
+    conf = openssl_file.read_text().splitlines(True)
+    # When the copy_extensions key is not in the configuration.
+    if "copy_extensions = copy\n" not in conf:
+        for idx, line in enumerate(conf):
+            if "[ CA_default ]" in line:
+                # Insert a new line with the copy_extensions key set to copy.
+                conf.insert(idx + 1, "copy_extensions = copy\n")
+        openssl_file.write_text("\n".join(conf))
 
-        # Ensure the openssl-*.cnf file is copied down to the pki directory
-        # Remove any existing openssl-*.cnf files in the pki directory.
-        pki_path = openssl_file.parent / "pki"
-        if pki_path.exists():
-            for cnf in pki_path.glob("openssl-*.cnf"):
-                cnf.unlink()
-            shutil.copyfile(openssl_file, pki_path / openssl_file.name)
+    # Ensure the openssl-*.cnf file is copied down to the pki directory
+    # Remove any existing openssl-*.cnf files in the pki directory.
+    pki_path = openssl_file.parent / "pki"
+    if pki_path.exists():
+        for cnf in pki_path.glob("openssl-*.cnf"):
+            cnf.unlink()
+        shutil.copyfile(openssl_file, pki_path / openssl_file.name)
 
 
 def configure_client_authorization():

--- a/src/reactive/easyrsa.py
+++ b/src/reactive/easyrsa.py
@@ -1,8 +1,8 @@
-import glob
 import ipaddress
 import os
 import shutil
 
+from pathlib import Path
 from os.path import islink
 from shlex import split
 from subprocess import check_call, check_output, CalledProcessError
@@ -109,23 +109,31 @@ def configure_easyrsa():
 
 
 def configure_copy_extensions():
-    """Update the EasyRSA configuration with the capacity to copy the exensions
+    """Update the EasyRSA configuration with the capacity to copy the extensions
     through to the resulting certificates."""
-    # Create an absolute path to the file which will not be impacted by cwd.
-    (openssl_file,) = glob.iglob(os.path.join(easyrsa_directory, "openssl-*.cnf"))
+
+    openssl_confs = Path(easyrsa_directory).glob("openssl-*.cnf")
     # Update EasyRSA configuration with the capacity to copy CSR Requested
     # Extensions through to the resulting certificate. This can be tricky,
     # and the implications are not fully clear on this.
-    with open(openssl_file, "r") as f:
-        conf = f.readlines()
-    # When the copy_extensions key is not in the configuration.
-    if "copy_extensions = copy\n" not in conf:
-        for idx, line in enumerate(conf):
-            if "[ CA_default ]" in line:
-                # Insert a new line with the copy_extensions key set to copy.
-                conf.insert(idx + 1, "copy_extensions = copy\n")
-        with open(openssl_file, "w+") as f:
-            f.writelines(conf)
+
+    for openssl_file in openssl_confs:
+        conf = openssl_file.read_text().splitlines(True)
+        # When the copy_extensions key is not in the configuration.
+        if "copy_extensions = copy\n" not in conf:
+            for idx, line in enumerate(conf):
+                if "[ CA_default ]" in line:
+                    # Insert a new line with the copy_extensions key set to copy.
+                    conf.insert(idx + 1, "copy_extensions = copy\n")
+            openssl_file.write_text("\n".join(conf))
+
+        # Ensure the openssl-*.cnf file is copied down to the pki directory
+        # Remove any existing openssl-*.cnf files in the pki directory.
+        pki_path = openssl_file.parent / "pki"
+        if pki_path.exists():
+            for cnf in pki_path.glob("openssl-*.cnf"):
+                cnf.unlink()
+            shutil.copyfile(openssl_file, pki_path / openssl_file.name)
 
 
 def configure_client_authorization():

--- a/src/reactive/easyrsa.py
+++ b/src/reactive/easyrsa.py
@@ -124,7 +124,7 @@ def configure_copy_extensions():
             if "[ CA_default ]" in line:
                 # Insert a new line with the copy_extensions key set to copy.
                 conf.insert(idx + 1, "copy_extensions = copy\n")
-        openssl_file.write_text("\n".join(conf))
+        openssl_file.write_text("".join(conf))
 
     # Ensure the openssl-*.cnf file is copied down to the pki directory
     # Remove any existing openssl-*.cnf files in the pki directory.

--- a/tests/unit/test_easyrsa.py
+++ b/tests/unit/test_easyrsa.py
@@ -258,7 +258,7 @@ class TestConfiguration(TestCase):
         pki_path.exists.return_value = False
         mock_glob.return_value = (mock_file,)
 
-        ssl_conf = "[ CA_default ]"
+        ssl_conf = "[ CA_default ]\n"
         expected_ssl_config_lines = [ssl_conf, "copy_extensions = copy\n"]
         mock_file.read_text.return_value = ssl_conf
 
@@ -267,9 +267,7 @@ class TestConfiguration(TestCase):
         easyrsa.configure_copy_extensions()
 
         # assert that the expected lines were written to the file
-        mock_file.write_text.assert_called_once_with(
-            "\n".join(expected_ssl_config_lines)
-        )
+        mock_file.write_text.assert_called_once_with("".join(expected_ssl_config_lines))
 
         # if the pki directory does not exist, no symlink should be created
         mock_copy.assert_not_called()


### PR DESCRIPTION
### Overview

The `EasyRSA-v3.0.1` release expects the `openssl-*.cnf` file only to exist in the top level directory.
The  `easyrsa-3.0.9` release creates this file in the `pki/` folder once the `init-pki` command is run the first time

If the `init-pki` is performed by `EasyRSA-v3.0.1`, then the `pki/` path won't have the configuration file there. 
If the `init-pki` is performed on `easyrsa-3.0.9`, then the `pki/` path is populated. 

In an upgrade scenario from 3.0.1 -> 3.0.9, the `pki/openssl-*.cnf` file is will be missing, and the `init-pki` step not performed again.  Therefore, we must copy in the existing configuration from the top level directory while removing any cnf from an older release