### PR TITLE
fix: use tarfile filter='data' for safe extraction (B202)

### DIFF
--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -126,7 +126,7 @@ def _replace_pki(pki_tar, pki_dir):
     shutil.move(pki_dir, safety_backup)
     try:
         log("Extracting pki from backup", hookenv.DEBUG)
-        pki_tar.extractall(easyrsa_directory)
+        pki_tar.extractall(easyrsa_directory, filter="data")
     except Exception as exc:
         log("pki extraction failed: {}".format(exc), hookenv.WARNING)
         log("Restoring original pki.", hookenv.INFO)

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -457,7 +457,7 @@ class RestoreActionTests(_ActionTestCase):
 
         # Test that `_replace_pki` safely unpacks pki backup.
         actions.shutil.move.assert_called_once_with(pki_dir, safety_backup)
-        pki_tar.extractall.assert_called_once_with(actions.easyrsa_directory)
+        pki_tar.extractall.assert_called_once_with(actions.easyrsa_directory, filter="data")
         actions.shutil.rmtree.assert_called_once_with(safety_backup)
 
     def test_path_traversal_in_backup_file(self):


### PR DESCRIPTION
## Summary

Use `tarfile.extractall(filter="data")` to guard against path traversal in tar entries, replacing the previous `# nosec B202` annotation.

The `filter="data"` option (Python 3.12+) strips unsafe tar metadata — absolute paths, symlinks to outside destinations, setuid/setgid bits — while still extracting file contents normally. This is the recommended fix for bandit B202.

## Context
Companion to the SAST workflows PR. Once both are merged, the bandit workflow will pass cleanly.