### PR TITLE
make PKI directory creation idempotent in create_certificate_authority (LP: #2154570)

### DIFF
--- a/src/reactive/easyrsa.py
+++ b/src/reactive/easyrsa.py
@@ -26,7 +26,6 @@ from charms.leadership import leader_get
 
 from charms.layer import status
 
-
 charm_directory = hookenv.charm_dir()
 easyrsa_directory = os.path.join(charm_directory, "EasyRSA")
 
@@ -200,8 +199,8 @@ def create_certificate_authority():
             # Bluff required files and folders.
             with open("pki/index.txt", "w") as f_out:
                 pass
-            os.makedirs("pki/issued")
-            os.makedirs("pki/certs_by_serial")
+            os.makedirs("pki/issued", exist_ok=True)
+            os.makedirs("pki/certs_by_serial", exist_ok=True)
 
         else:
             hookenv.log("Creating new CA")

--- a/tests/unit/test_easyrsa.py
+++ b/tests/unit/test_easyrsa.py
@@ -460,8 +460,8 @@ class TestCertificateManagement(TestCase):
             call(self.INDEX_FILE, "w"),
         ]
         expected_make_dirs = [
-            call("pki/issued"),
-            call("pki/certs_by_serial"),
+            call("pki/issued", exist_ok=True),
+            call("pki/certs_by_serial", exist_ok=True),
         ]
 
         # Setup mocks and handlers for cert/key/serial files


### PR DESCRIPTION
`create_certificate_authority` crashes with `FileExistsError` when a restored/replacement unit already has `pki/issued` and `pki/certs_by_serial` and then becomes leader. 

This change passed `exist_ok=True` to the two `os.makedirs` calls in `create_certificate_authority` (`pki/issued` and `pki/certs_by_serial`) so they no longer raise `FileExistsError` when the directories already exist.

Fixes: https://bugs.launchpad.net/charm-easyrsa/+bug/2154570